### PR TITLE
Add value 'auto' for literate option.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -28,7 +28,7 @@ formatOutput = (results, opt, literate) ->
     literate: literate
 
 
-coffeelintPlugin = (opt = null, literate = false, rules = []) ->
+coffeelintPlugin = (opt = null, literate = 'auto', rules = []) ->
     # register custom rules
     rules.map (rule) ->
         if typeof rule isnt 'function'
@@ -61,16 +61,23 @@ coffeelintPlugin = (opt = null, literate = false, rules = []) ->
         results = null
         output = null
 
+        if literate is 'auto'
+            currentLiterate = false
+            for ext in ['.litcoffee', '.coffee.md']
+                currentLiterate = true if file.path.slice(-(ext.length)) is ext
+        else
+            currentLiterate = !!literate
+
         # get results `Array`
         # see http://www.coffeelint.org/#api
         # for format
         results = coffeelint.lint(
             file.contents.toString(enc),
             opt,
-            literate
+            currentLiterate
         )
 
-        output = formatOutput results, opt, literate
+        output = formatOutput results, opt, currentLiterate
         file.coffeelint = output
 
         @push file

--- a/readme.md
+++ b/readme.md
@@ -33,10 +33,12 @@ Default: `null`
 By default it will walk up the directory tree looking for a `coffeelint.json` (per file, i.e. dirname) or a `package.json` that has a `coffeelintConfig` object ([as the cli does](http://www.coffeelint.org/#usage)). You may also pass in options you wish to send to `coffeelint` (see [http://www.coffeelint.org/#options](http://www.coffeelint.org/#options)) directly **or** you may enter the **absolute path** of a `.json` file containing such a configuration object.
 
 ### literate
-Type: `Boolean`
-Default: `false`
+Type: `Boolean` or `'auto'`
+Default: `'auto'`
 
 Are we dealing with literate CoffeeScript here?
+
+`'auto'` means `true` for `.litcoffee` and `.coffee.md` files, `false` for all other files.
 
 ### rules
 Type: `Array[Function]`
@@ -50,10 +52,10 @@ Adds the following properties to the `file` object:
 ```javascript
 file.coffeelint.success = true; // or false
 file.coffeelint.errorCount = 0; // number of errors returned by `coffeelint`
-file.coffeelint.warningCount = 0; // number of warnings returns by `coffeelint`
+file.coffeelint.warningCount = 0; // number of warnings returned by `coffeelint`
 file.coffeelint.results = []; // `coffeelint` results, see http://www.coffeelint.org/#api
-file.coffeelint.opt = {}; // The options you passed to `coffeelint`
-file.coffeelint.literate = false; // Again, this is your doing...
+file.coffeelint.opt = {}; // the options you passed to `coffeelint`
+file.coffeelint.literate = 'auto'; // you guessed it
 ```
 
 ## License

--- a/test/literate-detection.coffee
+++ b/test/literate-detection.coffee
@@ -1,0 +1,238 @@
+# module dependencies
+should = require 'should'
+gutil = require 'gulp-util'
+path = require 'path'
+
+# SUT
+coffeelint = require '../'
+
+# These tests are in separate file for readability.
+# Also coffeelint says cyclomatic complexity is too high when these tests
+# are merged with test/main.coffee.
+describe 'gulp-coffeelint', ->
+    describe 'coffeelint()', ->
+        describe 'CoffeeScript and Literate CoffeeScript detection', ->
+            describe 'should detect CoffeeScript', ->
+                it '... on .coffee with Literate contents', (done) ->
+                    dataCounter = 0
+
+                    fakeFile = new gutil.File
+                        path: './test/fixture/file.coffee',
+                        cwd: './test/',
+                        base: './test/fixture/',
+                        contents: new Buffer 'Comments!\n  yeah()'
+
+                    stream = coffeelint {}
+
+                    stream.on 'data', (newFile) ->
+                        ++dataCounter
+                        should.exist(newFile.coffeelint.success)
+                        should.exist(newFile.coffeelint.literate)
+                        newFile.coffeelint.success.should.be.false
+                        newFile.coffeelint.literate.should.be.false
+
+                    stream.once 'end', ->
+                        dataCounter.should.equal 1
+                        done()
+
+                    stream.write fakeFile
+                    stream.end()
+
+                it '... on .litcoffee with literate: false', (done) ->
+                    dataCounter = 0
+
+                    fakeFile = new gutil.File
+                        path: './test/fixture/file.litcoffee',
+                        cwd: './test/',
+                        base: './test/fixture/',
+                        contents: new Buffer 'Comments!\n  yeah()'
+
+                    stream = coffeelint {}, false
+
+                    stream.on 'data', (newFile) ->
+                        ++dataCounter
+                        should.exist(newFile.coffeelint.success)
+                        should.exist(newFile.coffeelint.literate)
+                        newFile.coffeelint.success.should.be.false
+                        newFile.coffeelint.literate.should.be.false
+
+                    stream.once 'end', ->
+                        dataCounter.should.equal 1
+                        done()
+
+                    stream.write fakeFile
+                    stream.end()
+
+                for extension in ['.coffee', '.js', '.custom', '.md', '.', '']
+                    ((extension) ->
+                        it '... on ' + (extension || 'no extension'), (done) ->
+                            dataCounter = 0
+
+                            fakeFile = new gutil.File
+                                path: './test/fixture/file' + extension,
+                                cwd: './test/',
+                                base: './test/fixture/',
+                                contents: new Buffer 'yeah()'
+
+                            stream = coffeelint {}
+
+                            stream.on 'data', (newFile) ->
+                                ++dataCounter
+                                should.exist(newFile.coffeelint.success)
+                                should.exist(newFile.coffeelint.literate)
+                                newFile.coffeelint.success.should.be.true
+                                newFile.coffeelint.literate.should.be.false
+
+                            stream.once 'end', ->
+                                dataCounter.should.equal 1
+                                done()
+
+                            stream.write fakeFile
+                            stream.end()
+                    )(extension)
+
+            describe 'should detect Literate CoffeeScript', ->
+                for extension in [ ".litcoffee", ".coffee.md" ]
+                    ((extension) ->
+                        it '... on ' + extension, (done) ->
+                            dataCounter = 0
+
+                            fakeFile = new gutil.File
+                                path: './test/fixture/file' + extension,
+                                cwd: './test/',
+                                base: './test/fixture/',
+                                contents: new Buffer 'Comments!\n  yeah()'
+
+                            stream = coffeelint {}
+
+                            stream.on 'data', (newFile) ->
+                                ++dataCounter
+                                should.exist(newFile.coffeelint.success)
+                                should.exist(newFile.coffeelint.literate)
+                                newFile.coffeelint.success.should.be.true
+                                newFile.coffeelint.literate.should.be.true
+
+                            stream.once 'end', ->
+                                dataCounter.should.equal 1
+                                done()
+
+                            stream.write fakeFile
+                            stream.end()
+                    )(extension)
+
+                it '... on .coffee with literate: true', (done) ->
+                    dataCounter = 0
+
+                    fakeFile = new gutil.File
+                        path: './test/fixture/file.coffee',
+                        cwd: './test/',
+                        base: './test/fixture/',
+                        contents: new Buffer 'yeah()'
+
+                    stream = coffeelint {}, true
+
+                    stream.on 'data', (newFile) ->
+                        ++dataCounter
+                        should.exist(newFile.coffeelint.success)
+                        should.exist(newFile.coffeelint.literate)
+                        newFile.coffeelint.success.should.be.true
+                        newFile.coffeelint.literate.should.be.true
+
+                    stream.once 'end', ->
+                        dataCounter.should.equal 1
+                        done()
+
+                    stream.write fakeFile
+                    stream.end()
+
+            describe 'multiple files', ->
+                it 'should detect CS and LCS in single stream', (done) ->
+                    dataCounter = 0
+
+                    extensions =
+                        '.coffee': false,
+                        '.litcoffee': true,
+                        '.js': false,
+                        '.coffee.md': true,
+                        '.md': false
+
+                    fakeFiles = for extension, literate of extensions
+                        fakeFile = new gutil.File
+                            path: './test/fixture/file' + extension,
+                            cwd: './test/',
+                            base: './test/fixture/',
+                            contents: new Buffer 'yeah()'
+                        fakeFile.literate = literate
+                        fakeFile
+
+                    stream = coffeelint {}
+
+                    stream.on 'data', (newFile) ->
+                        should.exist(newFile.coffeelint.success)
+                        should.exist(newFile.coffeelint.literate)
+                        newFile.coffeelint.literate.should.equal(
+                            newFile.literate)
+                        ++dataCounter
+
+                    stream.once 'end', ->
+                        dataCounter.should.equal 5
+                        done()
+
+                    stream.write fakeFile for fakeFile in fakeFiles
+                    stream.end()
+
+                it 'should treat all as LCS when literate: true', (done) ->
+                    dataCounter = 0
+
+                    extensions = ['.coffee', '.litcoffee', '.js',
+                        '.coffee.md', '.md']
+
+                    fakeFiles = for extension in extensions
+                        fakeFile = new gutil.File
+                            path: './test/fixture/file' + extension,
+                            cwd: './test/',
+                            base: './test/fixture/',
+                            contents: new Buffer 'yeah()'
+
+                    stream = coffeelint {}, true
+
+                    stream.on 'data', (newFile) ->
+                        should.exist(newFile.coffeelint.success)
+                        should.exist(newFile.coffeelint.literate)
+                        newFile.coffeelint.literate.should.be.true
+                        ++dataCounter
+
+                    stream.once 'end', ->
+                        dataCounter.should.equal 5
+                        done()
+
+                    stream.write fakeFile for fakeFile in fakeFiles
+                    stream.end()
+
+                it 'should treat all as CS when literate: false', (done) ->
+                    dataCounter = 0
+
+                    extensions = ['.coffee', '.litcoffee', '.js',
+                        '.coffee.md', '.md']
+
+                    fakeFiles = for extension in extensions
+                        fakeFile = new gutil.File
+                            path: './test/fixture/file' + extension,
+                            cwd: './test/',
+                            base: './test/fixture/',
+                            contents: new Buffer 'yeah()'
+
+                    stream = coffeelint {}, false
+
+                    stream.on 'data', (newFile) ->
+                        should.exist(newFile.coffeelint.success)
+                        should.exist(newFile.coffeelint.literate)
+                        newFile.coffeelint.literate.should.be.false
+                        ++dataCounter
+
+                    stream.once 'end', ->
+                        dataCounter.should.equal 5
+                        done()
+
+                    stream.write fakeFile for fakeFile in fakeFiles
+                    stream.end()


### PR DESCRIPTION
If literate === 'auto', treat .litcoffee and .coffee.md files
as literate CoffeeScript, assume everything other is CoffeeScript.

Make it default value.

Add tests for it in test/literate-detection.coffee,
mention about it in readme.md.

Btw, thanks for this awesome package, @janraasch!
