### PR TITLE
Fix for incorrect module dependency version syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,22 +27,22 @@
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "dependencies": {
-    "coffeelint": ">1.0.2",
+    "coffeelint": ">=1.0.2",
     "coffeelint-stylish": "0.0.1",
-    "gulp-util": ">2.2.5",
-    "through2": ">0.4.0",
-    "args-js": ">0.10.1"
+    "gulp-util": ">=2.2.5",
+    "through2": ">=0.4.0",
+    "args-js": ">=0.10.1"
   },
   "devDependencies": {
-    "coffee-script": ">1.7.1",
-    "mocha": ">1.17.0",
-    "istanbul": ">0.2.3",
-    "should": ">3.1.0",
-    "sinon": ">1.8.1",
-    "coveralls": ">2.8.0",
-    "gulp": ">3.5.2",
-    "gulp-coffee": ">1.4.1",
-    "gulp-clean": ">0.2.2",
+    "coffee-script": ">=1.7.1",
+    "mocha": ">=1.17.0",
+    "istanbul": ">=0.2.3",
+    "should": ">=3.1.0",
+    "sinon": ">=1.8.1",
+    "coveralls": ">=2.8.0",
+    "gulp": ">=3.5.2",
+    "gulp-coffee": ">=1.4.1",
+    "gulp-clean": ">=0.2.2",
     "conventional-changelog": "0.0.6",
     "coffeelint-use-strict": "0.0.1"
   },


### PR DESCRIPTION
As far as I can tell you've used caret (`^`) instead of great than (`>`) for "more than" module dependencies which leads to the following error:

``` shell
npm ERR! Error: No compatible version found: coffeelint@'^1.0.2'
npm ERR! Valid install targets:
npm ERR! ["0.0.1","0.0.2","0.0.3","0.0.4","0.0.5","0.0.6","0.0.7","0.1.0","0.2.0","0.3.0","0.4.0","0.5.0","0.5.1","0.5.2","0.5.3","0.5.4","0.5.5","0.5.6","0.5.7","0.6.0","0.6.1","1.0.0","1.0.1","1.0.2","1.0.3","1.0.4","1.0.5","1.0.6","1.0.7","1.0.8","1.1.0"]
```

I've updated `package.json` to correct this.
