### PR TITLE
Make CoffeeLint a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "dependencies": {
-    "coffeelint": "^1.4.0",
     "coffeelint-stylish": "^0.1.0",
     "gulp-util": "^2.2.5",
     "through2": "^0.4.0",
     "args-js": "^0.10.1"
   },
   "devDependencies": {
+    "coffeelint": "^1.4",
     "coffee-script": "^1.7.1",
     "mocha": "^1.17.0",
     "istanbul": "^0.2.3",
@@ -46,6 +46,10 @@
     "conventional-changelog": "0.0.9",
     "coffeelint-use-strict": "0.0.1"
   },
+  "peerDependencies": {
+    "coffeelint": "^1.4"
+  },
+
   "engines": {
     "npm": ">=1.3.7",
     "node": ">=0.10.0"


### PR DESCRIPTION
CoffeeLint 1.4 added the ability to the locally installed version of CoffeeLint when run from the command line. It uses the same mechanism as how `grunt-cli` gets globally installed, but runs your project's version of `grunt`. I haven't used `gulp`, so I don't know how it works.

Lets say a user has globally installed CoffeeLint 1.5, but their project using `gulp-coffeelint` is still using 1.4. As a `peerDependency` the user gets the same results (1.4) when run from the CLI (which is usually used by editor plugins) and from `gulp-coffeelint`.
