### PR TITLE
Don't show a big stack on failure

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -26,7 +26,8 @@ failReporter = ->
             return cb()
 
         # fail
-        @emit 'error', new Error "CoffeeLint failed for #{file.relative}"
+        @emit 'error',
+            createPluginError "CoffeeLint failed for #{file.relative}"
         cb()
 
 reporter = (type = 'default') ->


### PR DESCRIPTION
Throws a PluginError in the fail reporter, so that when the validation fails, the output looks like that:

![screen shot 2014-08-27 at 8 16 22 pm](https://cloud.githubusercontent.com/assets/1530203/4064997/d25c9c0a-2e16-11e4-8fc8-df1fcaded781.png)

instead of that:

![screen shot 2014-08-27 at 8 15 31 pm](https://cloud.githubusercontent.com/assets/1530203/4065003/df47c32c-2e16-11e4-88b9-cbd28583802e.png)
