### PR TITLE
Stop failing on warnings by default

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -6,8 +6,9 @@ stylish = require 'coffeelint-stylish'
 
 defaultReporter = ->
     through2.obj (file, enc, cb) ->
-        # nothing to report or no errors
-        if not file.coffeelint or file.coffeelint.success
+        c = file.coffeelint
+        # nothing to report or no errors AND no warnings
+        if not c or c.errorCount is c.warningCount is 0
             @push file
             return cb()
 
@@ -30,9 +31,23 @@ failReporter = ->
             createPluginError "CoffeeLint failed for #{file.relative}"
         cb()
 
+failOnWarningReporter = ->
+    through2.obj (file, enc, cb) ->
+        c = file.coffeelint
+        # nothing to report or no errors AND no warnings
+        if not c or c.errorCount is c.warningCount is 0
+            @push file
+            return cb()
+
+        # fail
+        @emit 'error',
+            createPluginError "CoffeeLint failed for #{file.relative}"
+        cb()
+
 reporter = (type = 'default') ->
     return defaultReporter() if type is 'default'
     return failReporter() if type is 'fail'
+    return failOnWarningReporter() if type is 'failOnWarning'
 
     # Otherwise
     throw createPluginError "#{type} is not a valid reporter"

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -19,7 +19,7 @@ exports.formatOutput = (results, opt, literate) ->
         warns++ if level is 'warn'
 
     # output
-    success: if results.length is 0 then true else false
+    success: errs is 0
     results: results
     errorCount: errs
     warningCount: warns

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ Add [custom rules](http://www.coffeelint.org/#api) to `coffeelint`.
 
 Adds the following properties to the `file` object:
 ```javascript
-file.coffeelint.success = true; // or false
+file.coffeelint.success = true; // if no errors were found, false otherwise
 file.coffeelint.errorCount = 0; // number of errors returned by `coffeelint`
 file.coffeelint.warningCount = 0; // number of warnings returned by `coffeelint`
 file.coffeelint.results = []; // `coffeelint` results, see http://www.coffeelint.org/#api
@@ -70,11 +70,13 @@ Assuming you would like to make use of those pretty results we have after piping
 ### name
 Type: `String`
 Default: `'default'`
-Possible Values: `'default'`, `'fail'`
+Possible Values: `'default'`, `'fail'`, `'failOnWarning'`
 
 * The `'default'` reporter uses [coffeelint-stylish](https://npmjs.org/package/coffeelint-stylish) to output a pretty report to the console. See [usage example](#usage) above.
 
-* If you would like your stream to `emit` an `error` (e.g. to fail the build on a CI server), when errors or warnings are found, use the `'fail'` reporter.
+* If you would like your stream to `emit` an `error` (e.g. to fail the build on a CI server) when errors are found, use the `'fail'` reporter.
+
+* If you want it to throw an error on both warnings and errors, use the `'failOnWarning'` reporter
 
 This example will log errors and warnings using the [coffeelint-stylish](https://npmjs.org/package/coffeelint-stylish) reporter, then fail if `coffeelint` was not a success.
 

--- a/test/main.coffee
+++ b/test/main.coffee
@@ -132,6 +132,34 @@ describe 'gulp-coffeelint', ->
             stream.write fakeFile
             stream.end()
 
+        it 'should send success status even when there are warnings', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'debugger'
+
+            stream = coffeelint 'no_debugger': 'level': 'warn'
+
+            stream.on 'data', (newFile) ->
+                ++dataCounter
+                should.exist newFile.coffeelint
+                should.exist newFile.coffeelint.success
+                should.exist newFile.coffeelint.warningCount
+                should.exist newFile.coffeelint.errorCount
+                newFile.coffeelint.success.should.be.true
+                newFile.coffeelint.warningCount.should.eql(1)
+                newFile.coffeelint.errorCount.should.eql(0)
+
+            stream.once 'end', ->
+                dataCounter.should.equal 1
+                done()
+
+            stream.write fakeFile
+            stream.end()
+
         it 'should send bad results', (done) ->
             dataCounter = 0
 

--- a/test/reporter.coffee
+++ b/test/reporter.coffee
@@ -19,6 +19,18 @@ ERR_MSG =
         'is not a valid reporter'
 
 describe 'gulp-coffeelint', ->
+    beforeEach ->
+        # reset statistics
+        countReporterCalls = 0
+        countFileNames = []
+        countResults = []
+
+        stub = sinon.stub reporter_module, 'reporter', ->
+            'I am a mocking bird'
+
+    afterEach ->
+        reporter_module.reporter.restore()
+
     describe 'coffeelint.reporter', ->
         it 'throws when passed invalid reporter type', (done) ->
             try
@@ -29,17 +41,6 @@ describe 'gulp-coffeelint', ->
                 done()
 
     describe 'coffeelint.reporter \'default\'', ->
-        beforeEach ->
-            # reset statistics
-            countReporterCalls = 0
-            countFileNames = []
-            countResults = []
-
-            stub = sinon.stub reporter_module, 'reporter', ->
-                'I am a mocking bird'
-        afterEach ->
-            reporter_module.reporter.restore()
-
         it 'should pass through a file', (done) ->
             dataCounter = 0
 
@@ -60,7 +61,6 @@ describe 'gulp-coffeelint', ->
                 newFile.relative.should.equal 'file.js'
                 ++dataCounter
 
-
             stream.once 'end', ->
                 dataCounter.should.equal 1
                 done()
@@ -68,7 +68,7 @@ describe 'gulp-coffeelint', ->
             stream.write fakeFile
             stream.end()
 
-        it 'only calls reporter if `file.coffeelint.success===false', (done) ->
+        it 'calls reporter if warnings', (done) ->
             dataCounter = 0
 
             fakeFile = new gutil.File
@@ -77,7 +77,10 @@ describe 'gulp-coffeelint', ->
                 base: './test/fixture/',
                 contents: new Buffer 'success()'
 
-            fakeFile.coffeelint = success: true
+            fakeFile.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 0
 
             fakeFile2 = new gutil.File
                 path: './test/fixture/file2.js',
@@ -85,8 +88,11 @@ describe 'gulp-coffeelint', ->
                 base: './test/fixture/',
                 contents: new Buffer 'yeahmetoo()'
 
-            fakeFile2.coffeelint = success: false, results: [bugs: 'many']
-
+            fakeFile2.coffeelint =
+                success: true,
+                warningCount: 2,
+                errorCount: 0,
+                results: [bugs: 'kinda']
 
             stream = coffeelint.reporter()
 
@@ -96,7 +102,48 @@ describe 'gulp-coffeelint', ->
             stream.once 'end', ->
                 dataCounter.should.equal 2
                 stub.calledOnce.should.equal true
-                (should stub.firstCall.args).eql ['file2.js', [bugs: 'many']]
+                (should stub.firstCall.args).eql ['file2.js', [bugs: 'kinda']]
+                done()
+
+            stream.write fakeFile
+            stream.write fakeFile2
+            stream.end()
+
+        it 'calls reporter if errors', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'success()'
+
+            fakeFile.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 2,
+                results: [bugs: 'some']
+
+            fakeFile2 = new gutil.File
+                path: './test/fixture/file2.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'yeahmetoo()'
+
+            fakeFile2.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 0,
+
+            stream = coffeelint.reporter()
+
+            stream.on 'data', (newFile) ->
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 2
+                stub.calledOnce.should.equal true
+                (should stub.firstCall.args).eql ['file.js', [bugs: 'some']]
                 done()
 
             stream.write fakeFile
@@ -193,8 +240,118 @@ describe 'gulp-coffeelint', ->
 
             stream.once 'end', ->
                 dataCounter.should.equal 2
-                stub.calledOnce.should.equal true
-                (should stub.firstCall.args).eql ['file2.js', [bugs: 'many']]
+                errorCounter.should.equal 1
+                done()
+
+            stream.on 'error', (e) ->
+                ++errorCounter
+                should.exist e
+                e.should.have.property 'message'
+                e.message.should.equal 'CoffeeLint failed for file2.js'
+
+            stream.write fakeFile
+            stream.write fakeFile2
+            stream.write fakeFile
+            stream.end()
+
+    describe 'coffeelint.reporter \'failOnWarning\'', ->
+
+        it 'should pass through an okay file', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'sure()'
+
+            stream = coffeelint.reporter 'failOnWarning'
+
+            stream.on 'data', (newFile) ->
+                should.exist(newFile)
+                should.exist(newFile.path)
+                should.exist(newFile.relative)
+                should.exist(newFile.contents)
+                newFile.path.should.equal './test/fixture/file.js'
+                newFile.relative.should.equal 'file.js'
+                ++dataCounter
+
+
+            stream.once 'end', ->
+                dataCounter.should.equal 1
+                done()
+
+            stream.write fakeFile
+            stream.end()
+
+        it 'should not pass thourgh a bad file', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'sure()'
+
+            fakeFile.coffeelint =
+                warningCount: 0,
+                errorCount: 1,
+                results: [bugs: 'some']
+
+            stream = coffeelint.reporter 'failOnWarning'
+
+            stream.on 'data', (newFile) ->
+                should.exist(newFile)
+                should.exist(newFile.path)
+                should.exist(newFile.relative)
+                should.exist(newFile.contents)
+                newFile.path.should.equal './test/fixture/file.js'
+                newFile.relative.should.equal 'file.js'
+                ++dataCounter
+
+            stream.on 'error', ->
+                # prevent stream from throwing
+
+            stream.once 'end', ->
+                dataCounter.should.equal 0
+                done()
+
+            stream.write fakeFile
+            stream.end()
+
+        it 'emits error if `file.coffeelint.warningCount!==0`', (done) ->
+            dataCounter = 0
+            errorCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'success()'
+
+            fakeFile.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 0
+
+            fakeFile2 = new gutil.File
+                path: './test/fixture/file2.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'yeahmetoo()'
+
+            fakeFile2.coffeelint =
+                warningCount: 1,
+                errorCount: 0,
+                results: [bugs: 'kinda']
+
+            stream = coffeelint.reporter 'failOnWarning'
+
+            stream.on 'data', (newFile) ->
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 2
                 errorCounter.should.equal 1
                 done()
 


### PR DESCRIPTION
I was a bit surprised when this plugin failed on warnings:
- usually things that issue warnings and errors, like compilers or [grunt-coffeelint](https://github.com/vojtajina/grunt-coffeelint), only fail on errors by default
- it seems to defeat the purpose of having 2 levels of reporting if we act the same for both

As of this PR, if you accept it:
- `coffeelint.success` is true unless there are errors, even if there are warnings
- hence, without any change to the `fail` reporter, it doesn't fail on warnings anymore
- there is a new `failOnWarning` reporter to reproduce the old behaviour

Also, this is based off janraasch/gulp-coffeelint#18 to include the output (IMESHO) improvement but let me know if you're keen on rejecting #18 and accepting this one, I'll be happy to change it.

Edit: It also fixes a small problem I spotted in the reporter spec, with a stub not being reset across tests, see f26bad9
