### PR TITLE
fix(fail reporter): nicer output on fail

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -26,7 +26,8 @@ failReporter = ->
             return cb()
 
         # fail
-        @emit 'error', new Error "CoffeeLint failed for #{file.relative}"
+        @emit 'error',
+            createPluginError "CoffeeLint failed for #{file.relative}"
         cb()
 
 reporter = (type = 'default') ->


### PR DESCRIPTION
Throws a PluginError instead of standard one in fail reporter, so that the fail output is a focused couple of lines nicely formatted by Gulp instead of a big noisy stack.

Reissue of #18 with a correct commit name.
