### PR TITLE
Specified last working version of coffeelint, and hard set all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "dependencies": {
-    "coffeelint": "1.4.0",
+    "coffeelint": "1.5.2",
     "coffeelint-stylish": "0.1.0",
     "gulp-util": "3.0.0",
     "through2": "0.6.1",


### PR DESCRIPTION
There is an issue with coffeelint > 1.5.2, which I have yet to track down.
