### PR TITLE
Support for CJSX

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -3,8 +3,6 @@
 fs = require 'fs'
 through2 = require 'through2'
 Args = require 'args-js' # main entry missing in `args-js` package
-coffeelint = require 'coffeelint'
-configfinder = require 'coffeelint/lib/configfinder'
 
 # `reporter`
 reporter = require './lib/reporter'
@@ -19,11 +17,12 @@ coffeelintPlugin = ->
         {opt: Args.OBJECT | Args.Optional}
         {literate: Args.BOOL | Args.Optional}
         {rules: Args.ARRAY | Args.Optional, _default: []}
+        {cjsx: Args.BOOL | Args.Optional}
     ]
 
     # parse arguments
     try
-        {opt, optFile, literate, rules} = Args params, arguments
+        {opt, optFile, literate, rules, cjsx} = Args params, arguments
     catch e
         throw createPluginError e
 
@@ -32,6 +31,11 @@ coffeelintPlugin = ->
     if Array.isArray opt
         rules = opt
         opt = undefined
+
+    # bring in the linter
+    coffeelintPkg = if cjsx then 'coffeelint-cjsx' else 'coffeelint'
+    coffeelint = require coffeelintPkg
+    configfinder = require coffeelintPkg + '/lib/configfinder'
 
     # register custom rules
     rules.map (rule) ->

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "url": "http://janraasch.com"
   },
   "files": [
-    "index.js",
-    "lib/*.js"
+    "index.coffee",
+    "lib/*.coffee"
   ],
   "scripts": {
     "prepublish": "gulp coffee --require \"coffee-script/register\"",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "coffeelint",
     "coffeescript",
     "coffee-script",
+    "cjsx",
+    "react",
+    "coffeelint-cjsx",
     "codeconventions"
   ],
   "repository": "janraasch/gulp-coffeelint",

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ gulp.task('lint', function () {
 
 ## API
 
-### `coffeelint([optFile,] [opt,] [literate,] [rules])`
+### `coffeelint([optFile,] [opt,] [literate,] [rules,] [cjsx])`
 All arguments are optional. By default `gulp-coffeelint` will walk up the directory tree looking for a `coffeelint.json` (per file, i.e. dirname) or a `package.json` that has a `coffeelintConfig` object ([as the cli does](http://www.coffeelint.org/#usage)). Also, `.litcoffee` and `.coffee.md` files will be treated as Literate CoffeeScript.
 
 ### optFile
@@ -49,6 +49,11 @@ Type: `Array[Function]`
 Default: `[]`
 
 Add [custom rules](http://www.coffeelint.org/#api) to `coffeelint`.
+
+### cjsx
+Type: `Boolean`
+
+Should we use [`coffeelint-cjsx`](https://www.npmjs.com/package/coffeelint-cjsx) instead of `coffeelint`?
 
 ## Results
 


### PR DESCRIPTION
Requires `coffeelint-cjsx` when the cjsx option is specified.