### PR TITLE
Allow custom coffeelint-reporters

### DIFF
--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -4,21 +4,6 @@ through2 = require 'through2'
 stylish = require 'coffeelint-stylish'
 {createPluginError} = require './utils'
 
-defaultReporter = ->
-    through2.obj (file, enc, cb) ->
-        c = file.coffeelint
-        # nothing to report or no errors AND no warnings
-        if not c or c.errorCount is c.warningCount is 0
-            @push file
-            return cb()
-
-        # report
-        stylish.reporter file.relative, file.coffeelint.results
-
-        # pass along
-        @push file
-        cb()
-
 failReporter = ->
     through2.obj (file, enc, cb) ->
         # nothing to report or no errors
@@ -44,12 +29,43 @@ failOnWarningReporter = ->
             createPluginError "CoffeeLint failed for #{file.relative}"
         cb()
 
+loadReporter = (reporter) ->
+    return reporter if typeof reporter is 'function'
+    if typeof reporter is 'object' and typeof reporter.reporter is 'function'
+        return reporter.reporter
+
+    if typeof reporter is 'string'
+        # Try to load CoffeeLint's build-in reporters
+        try
+            return loadReporter require('coffeelint/src/reporters/' + reporter)
+
+        # Try to load full-path and module reporters
+        try
+            return loadReporter require(reporter)
+
 reporter = (type = 'default') ->
-    return defaultReporter() if type is 'default'
     return failReporter() if type is 'fail'
     return failOnWarningReporter() if type is 'failOnWarning'
 
-    # Otherwise
-    throw createPluginError "#{type} is not a valid reporter"
+    rpt = stylish.reporter if type is 'default'
+    rpt = loadReporter(type) unless rpt?
+
+    unless typeof rpt is 'function'
+        throw createPluginError "#{type} is not a valid reporter"
+
+    # Return stream hooked to the loaded reporter
+    through2.obj (file, enc, cb) ->
+        c = file.coffeelint
+        # nothing to report or no errors AND no warnings
+        if not c or c.errorCount is c.warningCount is 0
+            @push file
+            return cb()
+
+        # report
+        rpt file.relative, file.coffeelint.results
+
+        # pass along
+        @push file
+        cb()
 
 module.exports = reporter

--- a/readme.md
+++ b/readme.md
@@ -64,26 +64,81 @@ file.coffeelint.literate = false; // you guessed it
 
 ## Reporters
 
-### `coffeelint.reporter(name)`
-Assuming you would like to make use of those pretty results we have after piping through `coffeelint()` there are some bundled reporters at your service.
-
 ### name
-Type: `String`
+Type: `String`, `Function`, or a `coffeelint-reporter`  
 Default: `'default'`
-Possible Values: `'default'`, `'fail'`, `'failOnWarning'`
 
-* The `'default'` reporter uses [coffeelint-stylish](https://npmjs.org/package/coffeelint-stylish) to output a pretty report to the console. See [usage example](#usage) above.
+### CoffeeLint reporters
 
-* If you would like your stream to `emit` an `error` (e.g. to fail the build on a CI server) when errors are found, use the `'fail'` reporter.
+#### Built-in
 
-* If you want it to throw an error on both warnings and errors, use the `'failOnWarning'` reporter
+You can choose any [CoffeeLint reporter](https://github.com/clutchski/coffeelint/tree/master/src/reporters)
+when you call
 
-This example will log errors and warnings using the [coffeelint-stylish](https://npmjs.org/package/coffeelint-stylish) reporter, then fail if `coffeelint` was not a success.
-
-```
+```js
+stuff
   .pipe(coffeelint())
-  .pipe(coffeelint.reporter())
+  .pipe(coffeelint.reporter('csv'))
+```
+
+#### External
+
+Let's use [coffeelint-stylish](https://github.com/janraasch/coffeelint-stylish) as an example
+
+```js
+var stylish = require('coffeelint-stylish');
+
+stuff
+  .pipe(coffeelint())
+  .pipe(coffeelint.reporter(stylish))
+```
+
+- OR -
+
+```js
+stuff
+  .pipe(coffeelint())
+  .pipe(coffeelint.reporter('coffelint-stylish'))
+```
+
+### Fail and FailOnWarning Reporters
+
+Do you want the task to fail when a CoffeeLint error or warning happens? gulp-coffeelint includes `fail` and `failOnWarning` reporters for this.
+
+This example will log the errors using the stylish reporter, then fail if CoffeeLint was not a success.
+
+```js
+stuff
+  .pipe(coffeelint())
+  .pipe(coffeelint.reporter('coffeelint-stylish'))
   .pipe(coffeelint.reporter('fail'))
+```
+
+### Custom Reporters
+
+Custom reporters don't interact with this module at all. CoffeeLint will add some attributes to the file object and you can add a custom reporter downstream.
+
+```js
+var jshint = require('gulp-coffeelint');
+var map = require('map-stream');
+
+var myReporter = map(function (file, cb) {
+  if (!file.coffeelint.success) {
+    console.log('CoffeeLint fail in '+file.path);
+    file.coffeelint.results.forEach(function (err) {
+      if (err) {
+        console.log(' '+file.path + ': line ' + err.line + ', col ' + err.character + ', code ' + err.code + ', ' + err.reason);
+      }
+    });
+  }
+  cb(null, file);
+});
+
+gulp.task('lint', function() {
+  return gulp.src('./lib/*.js')
+    .pipe(coffeelint())
+    .pipe(myReporter);
+});
 ```
 
 

--- a/test/literate-detection.coffee
+++ b/test/literate-detection.coffee
@@ -63,7 +63,7 @@ describe 'gulp-coffeelint', ->
 
             for extension in ['.coffee', '.js', '.custom', '.md', '.', '']
                 ((extension) ->
-                    it "on #{(extension || 'no extension')}", (done) ->
+                    it "on #{(extension or 'no extension')}", (done) ->
                         dataCounter = 0
 
                         fakeFile = new gutil.File

--- a/test/reporter.coffee
+++ b/test/reporter.coffee
@@ -32,9 +32,31 @@ describe 'gulp-coffeelint', ->
         reporter_module.reporter.restore()
 
     describe 'coffeelint.reporter', ->
+        it 'loads plugin \'default\' reporter', (done) ->
+            reporter = coffeelint.reporter('default')
+            should.exist(reporter)
+            done()
+
+        it 'loads builtin \'raw\' reporter', (done) ->
+            reporter = coffeelint.reporter('raw')
+            should.exist(reporter)
+            done()
+
+        it 'loads module \'coffeelint-stylish\' reporter', (done) ->
+            reporter = coffeelint.reporter('coffeelint-stylish')
+            should.exist(reporter)
+            done()
+
+        it 'loads full-path \'coffeelint/csv\' reporter', (done) ->
+            path = '../node_modules/coffeelint/src/reporters/csv.coffee'
+            reporter = coffeelint.reporter(path)
+            should.exist(reporter)
+            done()
+
         it 'throws when passed invalid reporter type', (done) ->
             try
                 coffeelint.reporter 'stupid'
+                done('should throw before encountered')
             catch e
                 should(e.plugin).equal PLUGIN_NAME
                 should(e.message).equal "stupid #{ERR_MSG.REPORTER}"


### PR DESCRIPTION
The current `gulp-coffeelint` implementation only supports the plugin's `default`, `fail`, and `failOnWarning` reporters. My intention was to extend the Reporter system to be more like `gulp-jshint`, allowing developers to specify other Reporters, including CoffeeLint's built-in reporters, module reporters, or even custom functions.

This PR aims to maintain the current functionality, `coffeelint.reporter()` and `coffeelint.reporter('default')` will both still invoke `coffeelint-stylish`, but now passing a string, function, or coffeelint-reporter to the function will now use that other reporter.

Much of the idea was poached from `gulp-jshint`. The documentation has also been updated, also primarily poached from `gulp-jshint`.

I tried to keep all styling the same. All tests pass, including new unit tests.

One note regarding maintaining functionality: CoffeeLint includes a `default` build-in reporter. By maintaining existing functionality, `coffeelint.reporter('default')` will invoke `coffeelint-stylish` rather than CoffeeLint's built-in default reporter. This is a difference in functionality from JSHint.