### PR TITLE
Allow Custom Reporters (v2)

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -76,13 +76,15 @@ coffeelintPlugin = ->
         # get results `Array`
         # see http://www.coffeelint.org/#api
         # for format
-        results = coffeelint.lint(
+        errorReport = coffeelint.getErrorReport()
+        errorReport.lint(
+            file.relative,
             file.contents.toString(),
             fileOpt,
             fileLiterate
         )
 
-        output = formatOutput results, fileOpt, fileLiterate
+        output = formatOutput errorReport, fileOpt, fileLiterate
         file.coffeelint = output
 
         @push file

--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -1,10 +1,9 @@
 'use strict'
 
 through2 = require 'through2'
-stylish = require 'coffeelint-stylish'
 {createPluginError} = require './utils'
 
-defaultReporter = ->
+reporterStream = (reporterType) ->
     through2.obj (file, enc, cb) ->
         c = file.coffeelint
         # nothing to report or no errors AND no warnings
@@ -13,7 +12,7 @@ defaultReporter = ->
             return cb()
 
         # report
-        rpt = new stylish(file.coffeelint.results)
+        rpt = new reporterType(file.coffeelint.results)
         rpt.publish()
 
         # pass along
@@ -45,12 +44,27 @@ failOnWarningReporter = ->
             createPluginError "CoffeeLint failed for #{file.relative}"
         cb()
 
-reporter = (type = 'default') ->
-    return defaultReporter() if type is 'default'
+reporter = (type) ->
     return failReporter() if type is 'fail'
     return failOnWarningReporter() if type is 'failOnWarning'
 
-    # Otherwise
-    throw createPluginError "#{type} is not a valid reporter"
+    type ?= 'coffeelint-stylish'
+    reporter = loadReporter(type)
+
+    unless typeof reporter is 'function'
+        throw createPluginError "#{type} is not a valid reporter"
+
+    return reporterStream(reporter)
+
+loadReporter = (reporter) ->
+    return reporter if typeof reporter is 'function'
+    if typeof reporter is 'string'
+        # Try to load CoffeeLint's build-in reporters
+        try
+            return require('coffeelint/lib/reporters/' + reporter)
+
+        # Try to load full-path and module reporters
+        try
+            return require(reporter)
 
 module.exports = reporter

--- a/lib/reporter.coffee
+++ b/lib/reporter.coffee
@@ -13,7 +13,8 @@ defaultReporter = ->
             return cb()
 
         # report
-        stylish.reporter file.relative, file.coffeelint.results
+        rpt = new stylish(file.coffeelint.results)
+        rpt.publish()
 
         # pass along
         @push file

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -8,19 +8,19 @@ exports.isLiterate = (file) ->
 exports.createPluginError = (message) ->
     new PluginError 'gulp-coffeelint', message
 
-exports.formatOutput = (results, opt, literate) ->
+exports.formatOutput = (errorReport, opt, literate) ->
     errs = 0
     warns = 0
 
     # some counting
-    results.map (result) ->
-        {level} = result
-        errs++ if level is 'error'
-        warns++ if level is 'warn'
+    for path, errors of errorReport.paths
+        for error in errors
+            errs++ if error.level is 'error'
+            warns++ if error.level is 'warn'
 
     # output
     success: errs is 0
-    results: results
+    results: errorReport
     errorCount: errs
     warningCount: warns
     opt: opt

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-coffee": "^2.1.2",
     "istanbul": "^0.3.0",
     "mocha": "^2.1.0",
+    "proxyquire": "^1.4.0",
     "should": "^5.0.0",
     "sinon": "^1.8.1"
   },

--- a/test/literate-detection.coffee
+++ b/test/literate-detection.coffee
@@ -63,7 +63,7 @@ describe 'gulp-coffeelint', ->
 
             for extension in ['.coffee', '.js', '.custom', '.md', '.', '']
                 ((extension) ->
-                    it "on #{(extension || 'no extension')}", (done) ->
+                    it "on #{(extension or 'no extension')}", (done) ->
                         dataCounter = 0
 
                         fakeFile = new gutil.File

--- a/test/main.coffee
+++ b/test/main.coffee
@@ -179,14 +179,19 @@ describe 'gulp-coffeelint', ->
                 newFile.coffeelint.success.should.be.false
                 newFile.coffeelint.errorCount.should.equal 1
                 newFile.coffeelint.warningCount.should.equal 0
-                newFile.coffeelint.results.should.be.an.instanceOf Array
-                newFile.coffeelint.results.should.not.be.empty
+                newFile.coffeelint.should.have.ownProperty 'results'
+                report = newFile.coffeelint.results
+                report.should.have.ownProperty 'paths'
+                report.paths.should.have.ownProperty 'file.js'
+                fileReport = report.paths['file.js']
+                fileReport.should.be.an.instanceOf Array
+                fileReport.should.not.be.empty
                 # see http://www.coffeelint.org/#api
-                newFile.coffeelint.results[0].level.should.equal 'error'
-                newFile.coffeelint.results[0].lineNumber.should.equal 1
-                should.exist newFile.coffeelint.results[0].message
-                should.exist newFile.coffeelint.results[0].description
-                should.exist newFile.coffeelint.results[0].rule
+                fileReport[0].level.should.equal 'error'
+                fileReport[0].lineNumber.should.equal 1
+                should.exist fileReport[0].message
+                should.exist fileReport[0].description
+                should.exist fileReport[0].rule
 
             stream.once 'end', ->
                 dataCounter.should.equal 1
@@ -214,17 +219,22 @@ describe 'gulp-coffeelint', ->
                 newFile.coffeelint.success.should.be.false
                 newFile.coffeelint.errorCount.should.equal 1
                 newFile.coffeelint.warningCount.should.equal 1
-                newFile.coffeelint.results.should.be.an.instanceOf Array
-                newFile.coffeelint.results.should.not.be.empty
+                newFile.coffeelint.should.have.ownProperty 'results'
+                report = newFile.coffeelint.results
+                report.should.have.ownProperty 'paths'
+                report.paths.should.have.ownProperty 'file.js'
+                fileReport = report.paths['file.js']
+                fileReport.should.be.an.instanceOf Array
+                fileReport.should.not.be.empty
                 # see http://www.coffeelint.org/#api
-                newFile.coffeelint.results[0].lineNumber.should.equal 1
-                should.exist newFile.coffeelint.results[0].message
-                should.exist newFile.coffeelint.results[0].description
-                should.exist newFile.coffeelint.results[0].rule
-                newFile.coffeelint.results[0].rule.should.equal(
+                fileReport[0].lineNumber.should.equal 1
+                should.exist fileReport[0].message
+                should.exist fileReport[0].description
+                should.exist fileReport[0].rule
+                fileReport[0].rule.should.equal(
                     'max_line_length'
                 )
-                should.exist newFile.coffeelint.results[0].context
+                should.exist fileReport[0].context
 
             stream.once 'end', ->
                 dataCounter.should.equal 1
@@ -255,17 +265,22 @@ describe 'gulp-coffeelint', ->
                 newFile.coffeelint.success.should.be.false
                 newFile.coffeelint.errorCount.should.equal 1
                 newFile.coffeelint.warningCount.should.equal 1
-                newFile.coffeelint.results.should.be.an.instanceOf Array
-                newFile.coffeelint.results.should.not.be.empty
+                newFile.coffeelint.should.have.ownProperty 'results'
+                report = newFile.coffeelint.results
+                report.should.have.ownProperty 'paths'
+                report.paths.should.have.ownProperty 'file.js'
+                fileReport = report.paths['file.js']
+                fileReport.should.be.an.instanceOf Array
+                fileReport.should.not.be.empty
                 # see http://www.coffeelint.org/#api
-                newFile.coffeelint.results[0].lineNumber.should.equal 1
-                should.exist newFile.coffeelint.results[0].message
-                should.exist newFile.coffeelint.results[0].description
-                should.exist newFile.coffeelint.results[0].rule
-                newFile.coffeelint.results[0].rule.should.equal(
+                fileReport[0].lineNumber.should.equal 1
+                should.exist fileReport[0].message
+                should.exist fileReport[0].description
+                should.exist fileReport[0].rule
+                fileReport[0].rule.should.equal(
                     'max_line_length'
                 )
-                should.exist newFile.coffeelint.results[0].context
+                should.exist fileReport[0].context
 
             stream.once 'end', ->
                 dataCounter.should.equal 1
@@ -293,17 +308,22 @@ describe 'gulp-coffeelint', ->
                 newFile.coffeelint.success.should.be.false
                 newFile.coffeelint.errorCount.should.equal 1
                 newFile.coffeelint.warningCount.should.equal 1
-                newFile.coffeelint.results.should.be.an.instanceOf Array
-                newFile.coffeelint.results.should.not.be.empty
+                newFile.coffeelint.should.have.ownProperty 'results'
+                report = newFile.coffeelint.results
+                report.should.have.ownProperty 'paths'
+                report.paths.should.have.ownProperty 'file.js'
+                fileReport = report.paths['file.js']
+                fileReport.should.be.an.instanceOf Array
+                fileReport.should.not.be.empty
                 # see http://www.coffeelint.org/#api
-                newFile.coffeelint.results[0].lineNumber.should.equal 1
-                should.exist newFile.coffeelint.results[0].message
-                should.exist newFile.coffeelint.results[0].description
-                should.exist newFile.coffeelint.results[0].rule
-                newFile.coffeelint.results[0].rule.should.equal(
+                fileReport[0].lineNumber.should.equal 1
+                should.exist fileReport[0].message
+                should.exist fileReport[0].description
+                should.exist fileReport[0].rule
+                fileReport[0].rule.should.equal(
                     'max_line_length'
                 )
-                should.exist newFile.coffeelint.results[0].context
+                should.exist fileReport[0].context
 
             stream.once 'end', ->
                 dataCounter.should.equal 1
@@ -331,14 +351,19 @@ describe 'gulp-coffeelint', ->
                 newFile.coffeelint.success.should.be.false
                 newFile.coffeelint.errorCount.should.equal 1
                 newFile.coffeelint.warningCount.should.equal 0
-                newFile.coffeelint.results.should.be.an.instanceOf Array
-                newFile.coffeelint.results.should.not.be.empty
+                newFile.coffeelint.should.have.ownProperty 'results'
+                report = newFile.coffeelint.results
+                report.should.have.ownProperty 'paths'
+                report.paths.should.have.ownProperty 'file.js'
+                fileReport = report.paths['file.js']
+                fileReport.should.be.an.instanceOf Array
+                fileReport.should.not.be.empty
                 # see http://www.coffeelint.org/#api
-                newFile.coffeelint.results[0].lineNumber.should.equal 1
-                should.exist newFile.coffeelint.results[0].message
-                should.exist newFile.coffeelint.results[0].description
-                should.exist newFile.coffeelint.results[0].rule
-                newFile.coffeelint.results[0].rule.should.equal(
+                fileReport[0].lineNumber.should.equal 1
+                should.exist fileReport[0].message
+                should.exist fileReport[0].description
+                should.exist fileReport[0].rule
+                fileReport[0].rule.should.equal(
                     'awesome_custom_rule'
                 )
 

--- a/test/reporter.coffee
+++ b/test/reporter.coffee
@@ -174,6 +174,441 @@ describe 'gulp-coffeelint', ->
             stream.write fakeFile2
             stream.end()
 
+    describe 'running coffeelint.reporter(\'raw\')', ->
+        coffeelint = null
+        publishStub = null
+        spiedReporter = null
+
+        beforeEach ->
+            selectedReporter = require 'coffeelint/lib/reporters/raw'
+            spiedReporter = sinon.spy selectedReporter
+            proxyReportHandler = proxyquire '../lib/reporter',
+                'coffeelint/lib/reporters/raw': spiedReporter
+
+            # SUT
+            coffeelint = proxyquire '../',
+                './lib/reporter': proxyReportHandler
+
+            publishStub = sinon.stub spiedReporter.prototype, 'publish', ->
+                'I am a mocking bird'
+
+        afterEach ->
+            spiedReporter.reset()
+            spiedReporter.prototype.publish.restore()
+
+        it 'should pass through a file', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'sure()'
+
+            stream = coffeelint.reporter('raw')
+
+            stream.on 'data', (newFile) ->
+                should.exist(newFile)
+                should.exist(newFile.path)
+                should.exist(newFile.relative)
+                should.exist(newFile.contents)
+                newFile.path.should.equal './test/fixture/file.js'
+                newFile.relative.should.equal 'file.js'
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 1
+                done()
+
+            stream.write fakeFile
+            stream.end()
+
+        it 'calls reporter if warnings', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'success()'
+
+            fakeFile.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 0
+
+            fakeFile2 = new gutil.File
+                path: './test/fixture/file2.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'yeahmetoo()'
+
+            fakeFile2.coffeelint =
+                success: true,
+                warningCount: 2,
+                errorCount: 0,
+                results:
+                    paths:
+                        'file2.js': [bugs: 'kinda']
+
+            stream = coffeelint.reporter('raw')
+
+            stream.on 'data', (newFile) ->
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 2
+                spiedReporter.callCount.should.equal 1
+                publishStub.callCount.should.equal 1
+                callArgs = spiedReporter.firstCall.args
+                (should callArgs).eql [
+                    paths:
+                        'file2.js': [bugs: 'kinda']
+                ]
+                done()
+
+            stream.write fakeFile
+            stream.write fakeFile2
+            stream.end()
+
+        it 'calls reporter if errors', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'success()'
+
+            fakeFile.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 2,
+                results:
+                    paths:
+                        'file.js': [bugs: 'some']
+
+            fakeFile2 = new gutil.File
+                path: './test/fixture/file2.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'yeahmetoo()'
+
+            fakeFile2.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 0,
+
+            stream = coffeelint.reporter('raw')
+
+            stream.on 'data', (newFile) ->
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 2
+                spiedReporter.callCount.should.equal 1
+                publishStub.callCount.should.equal 1
+                callArgs = spiedReporter.firstCall.args
+                (should callArgs).eql [
+                    paths:
+                        'file.js': [bugs: 'some']
+                ]
+                done()
+
+            stream.write fakeFile
+            stream.write fakeFile2
+            stream.end()
+
+    describe 'running coffeelint.reporter(\'coffeelint/lib/reporters/raw\')', ->
+        coffeelint = null
+        publishStub = null
+        spiedReporter = null
+
+        beforeEach ->
+            selectedReporter = require 'coffeelint/lib/reporters/raw'
+            spiedReporter = sinon.spy selectedReporter
+            proxyReportHandler = proxyquire '../lib/reporter',
+                'coffeelint/lib/reporters/raw': spiedReporter
+
+            # SUT
+            coffeelint = proxyquire '../',
+                './lib/reporter': proxyReportHandler
+
+            publishStub = sinon.stub spiedReporter.prototype, 'publish', ->
+                'I am a mocking bird'
+
+        afterEach ->
+            spiedReporter.reset()
+            spiedReporter.prototype.publish.restore()
+
+        it 'should pass through a file', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'sure()'
+
+            stream = coffeelint.reporter('coffeelint/lib/reporters/raw')
+
+            stream.on 'data', (newFile) ->
+                should.exist(newFile)
+                should.exist(newFile.path)
+                should.exist(newFile.relative)
+                should.exist(newFile.contents)
+                newFile.path.should.equal './test/fixture/file.js'
+                newFile.relative.should.equal 'file.js'
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 1
+                done()
+
+            stream.write fakeFile
+            stream.end()
+
+        it 'calls reporter if warnings', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'success()'
+
+            fakeFile.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 0
+
+            fakeFile2 = new gutil.File
+                path: './test/fixture/file2.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'yeahmetoo()'
+
+            fakeFile2.coffeelint =
+                success: true,
+                warningCount: 2,
+                errorCount: 0,
+                results:
+                    paths:
+                        'file2.js': [bugs: 'kinda']
+
+            stream = coffeelint.reporter('coffeelint/lib/reporters/raw')
+
+            stream.on 'data', (newFile) ->
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 2
+                spiedReporter.callCount.should.equal 1
+                publishStub.callCount.should.equal 1
+                callArgs = spiedReporter.firstCall.args
+                (should callArgs).eql [
+                    paths:
+                        'file2.js': [bugs: 'kinda']
+                ]
+                done()
+
+            stream.write fakeFile
+            stream.write fakeFile2
+            stream.end()
+
+        it 'calls reporter if errors', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'success()'
+
+            fakeFile.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 2,
+                results:
+                    paths:
+                        'file.js': [bugs: 'some']
+
+            fakeFile2 = new gutil.File
+                path: './test/fixture/file2.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'yeahmetoo()'
+
+            fakeFile2.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 0,
+
+            stream = coffeelint.reporter('coffeelint/lib/reporters/raw')
+
+            stream.on 'data', (newFile) ->
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 2
+                spiedReporter.callCount.should.equal 1
+                publishStub.callCount.should.equal 1
+                callArgs = spiedReporter.firstCall.args
+                (should callArgs).eql [
+                    paths:
+                        'file.js': [bugs: 'some']
+                ]
+                done()
+
+            stream.write fakeFile
+            stream.write fakeFile2
+            stream.end()
+
+    describe 'running coffeelint.reporter(\'coffeelint-stylish\')', ->
+        coffeelint = null
+        publishStub = null
+        spiedReporter = null
+
+        beforeEach ->
+            selectedReporter = require 'coffeelint-stylish'
+            spiedReporter = sinon.spy selectedReporter
+            proxyReportHandler = proxyquire '../lib/reporter',
+                'coffeelint-stylish': spiedReporter
+
+            # SUT
+            coffeelint = proxyquire '../',
+                './lib/reporter': proxyReportHandler
+
+            publishStub = sinon.stub spiedReporter.prototype, 'publish', ->
+                'I am a mocking bird'
+
+        afterEach ->
+            spiedReporter.reset()
+            spiedReporter.prototype.publish.restore()
+
+        it 'should pass through a file', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'sure()'
+
+            stream = coffeelint.reporter('coffeelint-stylish')
+
+            stream.on 'data', (newFile) ->
+                should.exist(newFile)
+                should.exist(newFile.path)
+                should.exist(newFile.relative)
+                should.exist(newFile.contents)
+                newFile.path.should.equal './test/fixture/file.js'
+                newFile.relative.should.equal 'file.js'
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 1
+                done()
+
+            stream.write fakeFile
+            stream.end()
+
+        it 'calls reporter if warnings', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'success()'
+
+            fakeFile.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 0
+
+            fakeFile2 = new gutil.File
+                path: './test/fixture/file2.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'yeahmetoo()'
+
+            fakeFile2.coffeelint =
+                success: true,
+                warningCount: 2,
+                errorCount: 0,
+                results:
+                    paths:
+                        'file2.js': [bugs: 'kinda']
+
+            stream = coffeelint.reporter('coffeelint-stylish')
+
+            stream.on 'data', (newFile) ->
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 2
+                spiedReporter.callCount.should.equal 1
+                publishStub.callCount.should.equal 1
+                callArgs = spiedReporter.firstCall.args
+                (should callArgs).eql [
+                    paths:
+                        'file2.js': [bugs: 'kinda']
+                ]
+                done()
+
+            stream.write fakeFile
+            stream.write fakeFile2
+            stream.end()
+
+        it 'calls reporter if errors', (done) ->
+            dataCounter = 0
+
+            fakeFile = new gutil.File
+                path: './test/fixture/file.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'success()'
+
+            fakeFile.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 2,
+                results:
+                    paths:
+                        'file.js': [bugs: 'some']
+
+            fakeFile2 = new gutil.File
+                path: './test/fixture/file2.js',
+                cwd: './test/',
+                base: './test/fixture/',
+                contents: new Buffer 'yeahmetoo()'
+
+            fakeFile2.coffeelint =
+                success: true,
+                warningCount: 0,
+                errorCount: 0,
+
+            stream = coffeelint.reporter('coffeelint-stylish')
+
+            stream.on 'data', (newFile) ->
+                ++dataCounter
+
+            stream.once 'end', ->
+                dataCounter.should.equal 2
+                spiedReporter.callCount.should.equal 1
+                publishStub.callCount.should.equal 1
+                callArgs = spiedReporter.firstCall.args
+                (should callArgs).eql [
+                    paths:
+                        'file.js': [bugs: 'some']
+                ]
+                done()
+
+            stream.write fakeFile
+            stream.write fakeFile2
+            stream.end()
+
     describe 'running coffeelint.reporter(\'fail\')', ->
         coffeelint = null
 

--- a/test/reporter.coffee
+++ b/test/reporter.coffee
@@ -4,19 +4,7 @@
 gutil = require 'gulp-util'
 should = require 'should'
 sinon = require 'sinon'
-proxyquire = require 'proxyquire'
-
-reporter = require 'coffeelint-stylish'
-spiedReporter = sinon.spy reporter
-proxyReportHandler = proxyquire '../lib/reporter',
-    'coffeelint-stylish': spiedReporter
-
-# SUT
-coffeelint = proxyquire '../',
-    './lib/reporter': proxyReportHandler
-
-# globals
-publishStub = null
+proxyquire = require('proxyquire').noPreserveCache()
 
 # const
 PLUGIN_NAME = 'gulp-coffeelint'
@@ -25,20 +13,14 @@ ERR_MSG =
         'is not a valid reporter'
 
 describe 'gulp-coffeelint', ->
-    beforeEach ->
-        # reset statistics
-        countReporterCalls = 0
-        countFileNames = []
-        countResults = []
 
-        publishStub = sinon.stub spiedReporter.prototype, 'publish', ->
-            'I am a mocking bird'
+    describe 'coffeelint.reporter function', ->
+        coffeelint = null
 
-    afterEach ->
-        spiedReporter.reset()
-        spiedReporter.prototype.publish.restore()
+        beforeEach ->
+            # SUT
+            coffeelint = require '../'
 
-    describe 'coffeelint.reporter', ->
         it 'throws when passed invalid reporter type', (done) ->
             try
                 coffeelint.reporter 'stupid'
@@ -47,7 +29,28 @@ describe 'gulp-coffeelint', ->
                 should(e.message).equal "stupid #{ERR_MSG.REPORTER}"
                 done()
 
-    describe 'coffeelint.reporter \'default\'', ->
+    describe 'running coffeelint.reporter()', ->
+        coffeelint = null
+        publishStub = null
+        spiedReporter = null
+
+        beforeEach ->
+            defaultReporter = require 'coffeelint-stylish'
+            spiedReporter = sinon.spy defaultReporter
+            proxyReportHandler = proxyquire '../lib/reporter',
+                'coffeelint-stylish': spiedReporter
+
+            # SUT
+            coffeelint = proxyquire '../',
+                './lib/reporter': proxyReportHandler
+
+            publishStub = sinon.stub spiedReporter.prototype, 'publish', ->
+                'I am a mocking bird'
+
+        afterEach ->
+            spiedReporter.reset()
+            spiedReporter.prototype.publish.restore()
+
         it 'should pass through a file', (done) ->
             dataCounter = 0
 
@@ -171,7 +174,12 @@ describe 'gulp-coffeelint', ->
             stream.write fakeFile2
             stream.end()
 
-    describe 'coffeelint.reporter \'fail\'', ->
+    describe 'running coffeelint.reporter(\'fail\')', ->
+        coffeelint = null
+
+        beforeEach ->
+            # SUT
+            coffeelint = require '../'
 
         it 'should pass through an okay file', (done) ->
             dataCounter = 0
@@ -276,7 +284,12 @@ describe 'gulp-coffeelint', ->
             stream.write fakeFile
             stream.end()
 
-    describe 'coffeelint.reporter \'failOnWarning\'', ->
+    describe 'running coffeelint.reporter(\'failOnWarning\')', ->
+        coffeelint = null
+
+        beforeEach ->
+            # SUT
+            coffeelint = require '../'
 
         it 'should pass through an okay file', (done) ->
             dataCounter = 0


### PR DESCRIPTION
Revised PR from #28

The current gulp-coffeelint implementation only supports the plugin's `default`, `fail`, and `failOnWarning` reporters. My intention was to extend the Reporter system to be more like gulp-jshint, allowing developers to specify other Reporters, including CoffeeLint's built-in reporters, module reporters, or even custom functions.

This PR aims to maintain the current functionality with `coffeelint.reporter()`, using `coffeelint-stylish` when no reporter is specified, but does create a **breaking change** with `coffeelint.reporter('default')` now using CoffeeLint's built-in `default` reporter, rather than `coffeelint-stylish`. To me, the risk seems minimal, since I would imagine most consumers use `coffeelint.reporter()` rather than `coffeelint.reporter('default')`.

Much of the concept was based on gulp-jshint. The documentation has also been updated, also primarily poached from gulp-jshint.

I tried to keep all styling the same, including all formatting and commit messages. All tests pass, including nine new unit tests to help cover conditions surrounding external reporters.

This PR also includes refactoring from the earlier plugin so that it uses `Reporter.publish()` rather than `Reporter.reporter(file, errors)`, as the latter was a non-standard method that was unique to `coffeelint-stylish`. It also includes refactoring from base `coffeelint.lint` results to `coffeelint.getErrorReport().lint` results, which introduces the `paths` property with path-keyed errors on the results property.

Because of the expectations from CoffeeLint reporters and their standardized `constructor` and `publish` functions, the plugin output and `errors` array changes from:
```
file.coffeelint.results: errors;
```
to
```
file.coffeelint.results: {
  paths: {
    'relative/gulp-src/filename.js': errors
  }
}

Finally, as an improvement over v1 of this PR (from #28), this version will load the JavaScript version of CoffeeLint's built-in reporters by referencing `coffeelint/lib/reporters` instead of the CoffeeScript versions within `coffeelint/src/reporters`.