### PR TITLE
docs(readme): fix usage example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ var gulp = require('gulp');
 var coffeelint = require('gulp-coffeelint');
 
 gulp.task('lint', function () {
-    gulp.src('./src/*.coffee')
+    return gulp.src('./src/*.coffee')
         .pipe(coffeelint())
         .pipe(coffeelint.reporter())
 });


### PR DESCRIPTION
Hi,

there is small bug in readme.md Usage section. You forgot to add "return". Without it it's not working correctly and other tasks are not waiting for coffeelint task to finish.